### PR TITLE
chore: support emoji for mkdocs

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -62,6 +62,9 @@ markdown_extensions:
   - attr_list
   - codehilite:
       guess_lang: false
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - fontawesome_markdown
   - footnotes
   - mdx_math


### PR DESCRIPTION
Fix the emoji of mkdocs.
@ito-san has [fixed this](https://github.com/autowarefoundation/open-ad-kit-docs/pull/32) before, but still needs to sync with autoware-documentation, or [the bot will complain](https://github.com/autowarefoundation/open-ad-kit-docs/pull/34).
I've updated [autoware-documentation](https://github.com/autowarefoundation/autoware-documentation/pull/230), and now try to sync again.
