### PR TITLE
chore: install necessary packages & add troubleshooting link to navigation page

### DIFF
--- a/docs/version-2.0/start-guide/how-to-run-simulators/.pages
+++ b/docs/version-2.0/start-guide/how-to-run-simulators/.pages
@@ -2,4 +2,5 @@ nav:
   - index.md
   - scenario-simulator
   - logging-simulator
+  - troubleshooting
   - limitations-and-issues

--- a/docs/version-2.0/start-guide/installation/boot-ewaol.md
+++ b/docs/version-2.0/start-guide/installation/boot-ewaol.md
@@ -31,6 +31,7 @@ Remove M.2 SSD from AVA platform and flash yocto image to it directly.
    :speech_balloon: For example
 
    ```console
+   sudo apt install bmap-tools
    sudo bmaptool copy --bmap build/tmp_baremetal/deploy/images/ava/ewaol-baremetal-image-ava.wic.bmap build/tmp_baremetal/deploy/images/ava/ewaol-baremetal-image-ava.wic.gz  /dev/sdb
    ```
 


### PR DESCRIPTION
The PR fixes the following:
1. install bmap-tools before using bmaptool
2. troubleshooting is not under the navigation page

![image](https://user-images.githubusercontent.com/456210/198976595-adf93a9b-b873-4302-9389-225548a7021b.png)
